### PR TITLE
Context's Get Their Task Type from the Scheduler

### DIFF
--- a/examples/cooperative-dynaimc-rr.zig
+++ b/examples/cooperative-dynaimc-rr.zig
@@ -6,7 +6,7 @@ const RoundRobin = @import("thoth").RoundRobinDynamic(stack_size);
 
 const stack_size = 16 * 1024;
 
-var scheduler: ThothScheduler(RoundRobin, stack_size) = undefined;
+var scheduler: ThothScheduler(RoundRobin) = undefined;
 
 pub fn foo() noreturn {
     while (true) {
@@ -38,7 +38,7 @@ pub fn main() noreturn {
     var rr = RoundRobin.init(alloc);
     defer rr.deinit();
 
-    scheduler = ThothScheduler(RoundRobin, stack_size).init(rr);
+    scheduler = ThothScheduler(RoundRobin).init(rr);
 
     scheduler.createTask(foo) catch @panic("Failed to register task");
     scheduler.createTask(bar) catch @panic("Failed to register task");

--- a/examples/cooperative.zig
+++ b/examples/cooperative.zig
@@ -7,7 +7,7 @@ const RoundRobin = @import("thoth").RoundRobin(max_tasks, stack_size);
 const stack_size = 16 * 1024;
 const max_tasks = 10;
 
-var scheduler: ThothScheduler(RoundRobin, stack_size) = undefined;
+var scheduler: ThothScheduler(RoundRobin) = undefined;
 
 pub fn foo() noreturn {
     var i: u32 = 0;
@@ -38,7 +38,7 @@ pub fn wootWoot() noreturn {
 
 pub fn main() noreturn {
     const rr = RoundRobin.init();
-    scheduler = ThothScheduler(RoundRobin, stack_size).init(rr);
+    scheduler = ThothScheduler(RoundRobin).init(rr);
 
     scheduler.createTask(foo) catch @panic("Failed to register task");
     scheduler.createTask(bar) catch @panic("Failed to register task");

--- a/examples/preemptive.zig
+++ b/examples/preemptive.zig
@@ -11,7 +11,7 @@ const US_PER_S: comptime_int = 1_000_000;
 const stack_size = 16 * 1024;
 const max_tasks = 10;
 
-var scheduler: ThothScheduler(RoundRobin, stack_size) = undefined;
+var scheduler: ThothScheduler(RoundRobin) = undefined;
 
 pub fn sigHandler(_: i32) callconv(.c) void {
     scheduler.yield();
@@ -37,7 +37,7 @@ pub fn dootDoot() noreturn {
 
 pub fn main() void {
     const rr = RoundRobin.init();
-    scheduler = ThothScheduler(RoundRobin, stack_size).init(rr);
+    scheduler = ThothScheduler(RoundRobin).init(rr);
 
     var action: std.os.linux.Sigaction = .{ .flags = std.os.linux.SA.SIGINFO | std.os.linux.SA.NODEFER, .mask = std.os.linux.empty_sigset, .handler = .{ .handler = sigHandler } };
 

--- a/src/arch/arm32.zig
+++ b/src/arch/arm32.zig
@@ -3,8 +3,9 @@
 
 const Task = @import("../task.zig").Task;
 
-pub fn Context(comptime stack_size: u32) type {
-    const TaskType = Task(stack_size);
+pub fn Context(comptime Scheduler: type) type {
+    const TaskType = Scheduler.getTaskType();
+
     return struct {
         const Self = @This();
 

--- a/src/arch/thumb.zig
+++ b/src/arch/thumb.zig
@@ -2,8 +2,9 @@
 
 const Task = @import("../task.zig").Task;
 
-pub fn Context(comptime stack_size: u32) type {
-    const TaskType = Task(stack_size);
+pub fn Context(comptime Scheduler: type) type {
+    const TaskType = Scheduler.getTaskType();
+
     return struct {
         const Self = @This();
 

--- a/src/arch/x86-64.zig
+++ b/src/arch/x86-64.zig
@@ -2,8 +2,9 @@
 
 const Task = @import("../task.zig").Task;
 
-pub fn Context(comptime stack_size: u32) type {
-    const TaskType = Task(stack_size);
+pub fn Context(comptime Scheduler: type) type {
+    const TaskType = Scheduler.getTaskType();
+
     return struct {
         const Self = @This();
         pub inline fn swapCtx(_: *const Self, from: *TaskType, to: *TaskType) void {

--- a/src/schedulers/rr-dyn.zig
+++ b/src/schedulers/rr-dyn.zig
@@ -62,12 +62,7 @@ pub fn RoundRobinDynamic(comptime stack_size: u32) type {
             }
 
             const task = &self.tasks[self.num_tasks];
-
-            task.* = .{
-                .ip = @intFromPtr(fun),
-                .sp = @intFromPtr(&task.stack[task.stack.len - @sizeOf(usize)]),
-                .stack = undefined,
-            };
+            task.initTask(fun);
 
             self.num_tasks += 1;
         }

--- a/src/schedulers/rr.zig
+++ b/src/schedulers/rr.zig
@@ -42,12 +42,7 @@ pub fn RoundRobin(comptime max_tasks: u32, comptime stack_size: u32) type {
             }
 
             const task = &self.tasks[self.num_tasks];
-
-            task.* = .{
-                .ip = @intFromPtr(fun),
-                .sp = @intFromPtr(&task.stack[task.stack.len - @sizeOf(usize)]),
-                .stack = undefined,
-            };
+            task.initTask(fun);
 
             self.num_tasks += 1;
         }

--- a/src/task.zig
+++ b/src/task.zig
@@ -1,11 +1,22 @@
 //! Task definition
 
 const std = @import("std");
+const TaskFn = @import("thoth.zig").TaskFn;
 
 pub fn Task(comptime stack_size: u32) type {
     return struct {
         stack: [stack_size]u8 = undefined,
         sp: usize,
         ip: usize,
+
+        const Self = @This();
+
+        pub fn initTask(task: *Self, fun: TaskFn) void {
+            task.* = .{
+                .ip = @intFromPtr(fun),
+                .sp = @intFromPtr(&task.stack[task.stack.len - @sizeOf(usize)]),
+                .stack = undefined,
+            };
+        }
     };
 }

--- a/src/thoth.zig
+++ b/src/thoth.zig
@@ -14,7 +14,7 @@ pub const RoundRobinDynamic = @import("schedulers/rr-dyn.zig").RoundRobinDynamic
 pub const TaskFn = *const fn () noreturn;
 pub const SchedulerErrors = error{ AllTasksRegistered, NoTasksRegistered };
 
-pub fn ThothScheduler(comptime Scheduler: type, comptime stack_size: u32) type {
+pub fn ThothScheduler(comptime Scheduler: type) type {
     const Task = Scheduler.getTaskType();
 
     return struct {
@@ -24,9 +24,9 @@ pub fn ThothScheduler(comptime Scheduler: type, comptime stack_size: u32) type {
         ctx: Context,
 
         pub const Context = switch (builtin.cpu.arch) {
-            .x86_64 => X86_64Context(stack_size),
-            .arm => ARMContext(stack_size),
-            .thumb => ThumbContext(stack_size),
+            .x86_64 => X86_64Context(Scheduler),
+            .arm => ARMContext(Scheduler),
+            .thumb => ThumbContext(Scheduler),
             else => @compileError("Unsupported CPU architecture: " ++ @tagName(builtin.cpu.arch)),
         };
 


### PR DESCRIPTION
This mostly just means we 

1. Could make a scheduler with a task type that doesn't need a specific stack size
2. Don't need to give stack size to `ThothScheduler`