### PR TITLE
Introduce an API for performing IO Bound calls (handled by the underlying scheduler)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,26 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run the unit tests");
     test_step.dependOn(&run_unit_tests.step);
 
+    const sim = b.addExecutable(.{
+        .name = "simulation",
+        .root_source_file = b.path("examples/printer.zig"),
+        .target = b.graph.host,
+    });
+
+    sim.root_module.addImport("thoth", thoth_mod);
+
+    b.installArtifact(sim);
+
+    const sim_cmd = b.addRunArtifact(sim);
+    sim_cmd.step.dependOn(b.getInstallStep());
+
+    const sim_step = b.step("sim", "Run the sample 3D printer RTOS simulation");
+    if (b.args) |args| {
+        sim_cmd.addArgs(args);
+    }
+
+    sim_step.dependOn(&sim_cmd.step);
+
     const coop = b.addExecutable(.{
         .name = "cooperative",
         .root_source_file = b.path("examples/cooperative.zig"),

--- a/examples/printer.zig
+++ b/examples/printer.zig
@@ -10,7 +10,9 @@ const max_tasks = 10;
 var scheduler: ThothScheduler(RoundRobin) = undefined;
 
 var current_temp: u16 = 0;
-var target_temp: u16 = 200;
+var target_temp: u16 = 0;
+var step_count: u32 = 0;
+var target_steps: u32 = 1000;
 
 pub fn temperatureMonitorTask() noreturn {
     while (true) {
@@ -25,9 +27,6 @@ pub fn temperatureMonitorTask() noreturn {
         scheduler.ioYield(.{ .call_type = .sleep, .time_out = 100_000 });
     }
 }
-
-var step_count: u32 = 0;
-var target_steps: u32 = 1000;
 
 pub fn stepperMotorTask() noreturn {
     while (step_count < target_steps) {
@@ -62,6 +61,8 @@ pub fn gcodeProcessorTask() noreturn {
 pub fn main() noreturn {
     const rr = RoundRobin.init();
     scheduler = ThothScheduler(RoundRobin).init(rr);
+
+    target_temp = 250;
 
     scheduler.createTask(temperatureMonitorTask);
     scheduler.createTask(stepperMotorTask);

--- a/examples/simulation.zig
+++ b/examples/simulation.zig
@@ -63,5 +63,9 @@ pub fn main() noreturn {
     const rr = RoundRobin.init();
     scheduler = ThothScheduler(RoundRobin).init(rr);
 
+    scheduler.createTask(temperatureMonitorTask);
+    scheduler.createTask(stepperMotorTask);
+    scheduler.createTask(gcodeProcessorTask);
+
     scheduler.start() catch unreachable;
 }

--- a/examples/simulation.zig
+++ b/examples/simulation.zig
@@ -1,0 +1,67 @@
+//! Simulation Task Definitions
+
+const std = @import("std");
+const ThothScheduler = @import("thoth").ThothScheduler;
+const RoundRobin = @import("thoth").RoundRobin(max_tasks, stack_size);
+
+const stack_size = 16 * 1024;
+const max_tasks = 10;
+
+var scheduler: ThothScheduler(RoundRobin) = undefined;
+
+var current_temp: u16 = 0;
+var target_temp: u16 = 200;
+
+pub fn temperatureMonitorTask() noreturn {
+    while (true) {
+        scheduler.ioYield(.{ .call_type = .adc_read, .time_out = 50 });
+
+        if (current_temp < target_temp) {
+            scheduler.ioYield(.{ .call_type = .gpio_interrupt, .time_out = 1 });
+        }
+
+        scheduler.ioYield(.{ .call_type = .uart_transmit, .time_out = 20 });
+
+        scheduler.ioYield(.{ .call_type = .sleep, .time_out = 100_000 });
+    }
+}
+
+var step_count: u32 = 0;
+var target_steps: u32 = 1000;
+
+pub fn stepperMotorTask() noreturn {
+    while (step_count < target_steps) {
+        scheduler.ioYield(.{ .call_type = .gpio_interrupt, .time_out = 2 });
+
+        scheduler.ioYield(.{ .call_type = .gpio_interrupt, .time_out = 1 });
+
+        step_count += 1;
+        scheduler.ioYield(.{ .call_type = .sleep, .time_out = 2_000 });
+    }
+
+    scheduler.ret();
+}
+
+pub fn gcodeProcessorTask() noreturn {
+    var gcode_buffer: [64]u8 = undefined;
+
+    while (true) {
+        scheduler.ioYield(.{ .call_type = .uart_receive, .time_out = 100 });
+
+        var i: u32 = 0;
+        while (i < 1000) : (i += 1) {
+            gcode_buffer[i % 64] += i;
+        }
+
+        scheduler.ioYield(.{ .call_type = .uart_transmit, .time_out = 50 });
+
+        scheduler.ioYield(.{ .call_type = .sleep, .time_out = 50_000 });
+    }
+}
+
+pub fn main() noreturn {
+    const rr = RoundRobin.init();
+    scheduler = ThothScheduler(RoundRobin).init(rr);
+
+    scheduler.start() catch unreachable;
+}

--- a/src/arch/x86-64.S
+++ b/src/arch/x86-64.S
@@ -1,7 +1,6 @@
 .section .text
 
 .global context_switch
-.type context_switch, @function
 context_switch:
     leaq 1f(%rip), %rax
     movq %rax, (%rsi)
@@ -12,7 +11,6 @@ context_switch:
     ret
 
 .global context_start
-.type context_start, @function
 context_start:
     mov %rdi, %rsp
     jmp *%rsi

--- a/src/io.zig
+++ b/src/io.zig
@@ -1,0 +1,21 @@
+//! IO Bound 'Syscall' enums. This is for simulation use currently but
+//! will be fully implemented for baremetal runtimes
+
+pub const IoCall = enum(u8) {
+    uart_transmit,
+    uart_receive,
+    i2c_read,
+    i2c_write,
+    spi_transfer,
+
+    gpio_interrupt,
+
+    adc_read,
+
+    sleep,
+};
+
+pub const IoSimCall = struct {
+    call_type: IoCall,
+    time_out: u32,
+};

--- a/src/schedulers/rr.zig
+++ b/src/schedulers/rr.zig
@@ -2,6 +2,7 @@
 
 const Task = @import("../task.zig").Task;
 const thoth = @import("../thoth.zig");
+const IoReq = @import("../io.zig").IoSimCall;
 const SchedulerErrors = thoth.SchedulerErrors;
 const TaskFn = thoth.TaskFn;
 
@@ -17,6 +18,10 @@ pub fn RoundRobin(comptime max_tasks: u32, comptime stack_size: u32) type {
 
         pub fn getTaskType() type {
             return Task(stack_size);
+        }
+
+        pub fn getIoType() type {
+            return IoReq;
         }
 
         pub fn init() Self {
@@ -54,6 +59,11 @@ pub fn RoundRobin(comptime max_tasks: u32, comptime stack_size: u32) type {
             }
 
             return &self.tasks[self.curr_task];
+        }
+
+        pub inline fn ioYield(self: *Self, io: IoReq) *Task(stack_size) {
+            _ = io;
+            return self.getNext();
         }
     };
 }

--- a/src/thoth.zig
+++ b/src/thoth.zig
@@ -43,9 +43,10 @@ pub fn ThothScheduler(comptime Scheduler: type) type {
             try self.scheduler.register(fun);
         }
 
-        pub fn ret(self: *Self) void {
+        pub fn ret(self: *Self) noreturn {
             self.curr.returned = 1;
             self.yield();
+            unreachable;
         }
 
         pub fn ioYield(self: *Self, io: IoReq) void {

--- a/src/thoth.zig
+++ b/src/thoth.zig
@@ -45,6 +45,13 @@ pub fn ThothScheduler(comptime Scheduler: type) type {
             self.yield();
         }
 
+        pub fn ioYield(self: *Self, io: i32) void {
+            // TODO: store IO history info
+            _ = io;
+
+            yield(self);
+        }
+
         pub fn yield(self: *Self) void {
             const curr = self.curr;
             const next = self.scheduler.getNext();

--- a/src/thoth.zig
+++ b/src/thoth.zig
@@ -49,11 +49,13 @@ pub fn ThothScheduler(comptime Scheduler: type) type {
             unreachable;
         }
 
-        pub fn ioYield(self: *Self, io: IoReq) void {
-            // TODO: store IO history info
-            _ = io;
+        pub fn ioYield(self: *Self, io: Scheduler.getIoType()) void {
+            const curr = self.curr;
+            const next = self.scheduler.ioYield(io);
 
-            yield(self);
+            self.curr = next;
+
+            self.ctx.swapCtx(curr, next);
         }
 
         pub fn yield(self: *Self) void {

--- a/src/thoth.zig
+++ b/src/thoth.zig
@@ -8,6 +8,9 @@ const X86_64Context = @import("arch/x86-64.zig").Context;
 const ARMContext = @import("arch/arm32.zig").Context;
 const ThumbContext = @import("arch/thumb.zig").Context;
 
+pub const IoCall = @import("io.zig").IoCall;
+pub const IoReq = @import("io.zig").IoSimCall;
+
 pub const RoundRobin = @import("schedulers/rr.zig").RoundRobin;
 pub const RoundRobinDynamic = @import("schedulers/rr-dyn.zig").RoundRobinDynamic;
 
@@ -45,7 +48,7 @@ pub fn ThothScheduler(comptime Scheduler: type) type {
             self.yield();
         }
 
-        pub fn ioYield(self: *Self, io: i32) void {
+        pub fn ioYield(self: *Self, io: IoReq) void {
             // TODO: store IO history info
             _ = io;
 

--- a/src/thoth.zig
+++ b/src/thoth.zig
@@ -8,9 +8,6 @@ const X86_64Context = @import("arch/x86-64.zig").Context;
 const ARMContext = @import("arch/arm32.zig").Context;
 const ThumbContext = @import("arch/thumb.zig").Context;
 
-pub const IoCall = @import("io.zig").IoCall;
-pub const IoReq = @import("io.zig").IoSimCall;
-
 pub const RoundRobin = @import("schedulers/rr.zig").RoundRobin;
 pub const RoundRobinDynamic = @import("schedulers/rr-dyn.zig").RoundRobinDynamic;
 


### PR DESCRIPTION
IO Bound calls can now be requested from tasks. The type of this `IoRequest` is held within the context of the Scheduler itself. This means we can create simulation IO calls that just sleep for some time, or real implementations in an RTOS. Create a sample simulation with a couple tasks you might see in a 3D printer as a part of my feature collection for UGR