### PR TITLE
Store all Registers on all Architectures

### DIFF
--- a/src/arch/arm32.S
+++ b/src/arch/arm32.S
@@ -1,18 +1,43 @@
 .section .text
+.syntax unified
+.arm
 
 .global context_switch
 .type context_switch, %function
 context_switch:
-    adr x8, 1f
-    str x8, [x1]
-    str sp, [x0]
-    mov sp, x2
-    br x3
+    ldr r12, =1f
+    str r12, [r1]
+    
+    str r4, [r0, #12]
+    str r5, [r0, #16]
+    str r6, [r0, #20]
+    str r7, [r0, #24]
+    str r8, [r0, #28]
+    str r9, [r0, #32]
+    str r10, [r0, #36]
+    str r11, [r0, #40]
+    str sp, [r0]
+    str lr, [r0, #44]
+    
+    mov sp, r2
+    
+    ldr r4, [r2, #12]
+    ldr r5, [r2, #16]
+    ldr r6, [r2, #20]
+    ldr r7, [r2, #24]
+    ldr r8, [r2, #28]
+    ldr r9, [r2, #32]
+    ldr r10, [r2, #36]
+    ldr r11, [r2, #40]
+    ldr lr, [r2, #44]
+    
+    bx r3
+
 1:
-    ret
+    bx lr
 
 .global context_start
 .type context_start, %function
 context_start:
-    mov sp, x0
-    br x1
+    mov sp, r0
+    bx r1

--- a/src/arch/thumb.S
+++ b/src/arch/thumb.S
@@ -8,9 +8,32 @@
 context_switch:
     ldr r4, =1f
     str r4, [r1]
+    
+    str r4, [r0, #12]
+    str r5, [r0, #16]
+    str r6, [r0, #20]
+    str r7, [r0, #24]
+    str r8, [r0, #28]
+    str r9, [r0, #32]
+    str r10, [r0, #36]
+    str r11, [r0, #40]
     str sp, [r0]
+    str lr, [r0, #44]
+    
     mov sp, r2
+    
+    ldr r4, [r2, #12]
+    ldr r5, [r2, #16]
+    ldr r6, [r2, #20]
+    ldr r7, [r2, #24]
+    ldr r8, [r2, #28]
+    ldr r9, [r2, #32]
+    ldr r10, [r2, #36]
+    ldr r11, [r2, #40]
+    ldr lr, [r2, #44]
+    
     bx r3
+
 1:
     bx lr
 

--- a/src/arch/x86-64.S
+++ b/src/arch/x86-64.S
@@ -4,13 +4,30 @@
 context_switch:
     leaq 1f(%rip), %rax
     movq %rax, (%rsi)
+    
+    movq %rbx, 32(%rdi)
+    movq %rbp, 40(%rdi) 
+    movq %r12, 48(%rdi)
+    movq %r13, 56(%rdi)
+    movq %r14, 64(%rdi)
+    movq %r15, 72(%rdi)
     movq %rsp, (%rdi)
+    
     movq %rdx, %rsp
+    
+    movq 32(%rdx), %rbx
+    movq 40(%rdx), %rbp
+    movq 48(%rdx), %r12
+    movq 56(%rdx), %r13
+    movq 64(%rdx), %r14
+    movq 72(%rdx), %r15
+    
     jmp *%rcx
+
 1:
     ret
 
 .global context_start
 context_start:
-    mov %rdi, %rsp
+    movq %rdi, %rsp
     jmp *%rsi

--- a/src/task.zig
+++ b/src/task.zig
@@ -1,9 +1,19 @@
 //! Task definition
 
 const std = @import("std");
+const builtin = @import("builtin");
 const TaskFn = @import("thoth.zig").TaskFn;
 
 pub fn Task(comptime stack_size: u32) type {
+    switch (builtin.cpu.arch) {
+        .x86_64 => return x86Task(stack_size),
+        .arm => return Arm32Task(stack_size),
+        .thumb => return ThumbTask(stack_size),
+        else => @compileError("Unsupported CPU architecture: " ++ @tagName(builtin.cpu.arch)),
+    }
+}
+
+pub fn x86Task(comptime stack_size: u32) type {
     return struct {
         stack: [stack_size]u8 = undefined,
         sp: usize,
@@ -33,6 +43,85 @@ pub fn Task(comptime stack_size: u32) type {
                 .r13 = 0,
                 .r14 = 0,
                 .r15 = 0,
+            };
+        }
+    };
+}
+pub fn Arm32Task(comptime stack_size: u32) type {
+    return struct {
+        stack: [stack_size]u8 = undefined,
+        sp: usize,
+        ip: usize,
+        returned: usize,
+
+        r4: usize,
+        r5: usize,
+        r6: usize,
+        r7: usize,
+        r8: usize,
+        r9: usize,
+        r10: usize,
+        r11: usize,
+        r14: usize,
+
+        const Self = @This();
+
+        pub fn initTask(task: *Self, fun: TaskFn) void {
+            task.* = .{
+                .ip = @intFromPtr(fun),
+                .sp = @intFromPtr(&task.stack[task.stack.len - @sizeOf(u32)]),
+                .stack = undefined,
+                .returned = 0,
+                .padding = undefined,
+                .r4 = 0,
+                .r5 = 0,
+                .r6 = 0,
+                .r7 = 0,
+                .r8 = 0,
+                .r9 = 0,
+                .r10 = 0,
+                .r11 = 0,
+                .r14 = 0,
+            };
+        }
+    };
+}
+
+pub fn ThumbTask(comptime stack_size: u32) type {
+    return struct {
+        stack: [stack_size]u8 = undefined,
+        sp: usize,
+        ip: usize,
+        returned: usize,
+
+        r4: usize,
+        r5: usize,
+        r6: usize,
+        r7: usize,
+        r8: usize,
+        r9: usize,
+        r10: usize,
+        r11: usize,
+        r14: usize,
+
+        const Self = @This();
+
+        pub fn initTask(task: *Self, fun: TaskFn) void {
+            task.* = .{
+                .ip = @intFromPtr(fun),
+                .sp = @intFromPtr(&task.stack[task.stack.len - @sizeOf(u32)]),
+                .stack = undefined,
+                .returned = 0,
+                .padding = undefined,
+                .r4 = 0,
+                .r5 = 0,
+                .r6 = 0,
+                .r7 = 0,
+                .r8 = 0,
+                .r9 = 0,
+                .r10 = 0,
+                .r11 = 0,
+                .r14 = 0,
             };
         }
     };

--- a/src/task.zig
+++ b/src/task.zig
@@ -11,6 +11,13 @@ pub fn Task(comptime stack_size: u32) type {
         returned: usize,
         padding: usize,
 
+        rbx: usize,
+        rbp: usize,
+        r12: usize,
+        r13: usize,
+        r14: usize,
+        r15: usize,
+
         const Self = @This();
 
         pub fn initTask(task: *Self, fun: TaskFn) void {
@@ -20,6 +27,12 @@ pub fn Task(comptime stack_size: u32) type {
                 .stack = undefined,
                 .returned = 0,
                 .padding = undefined,
+                .rbx = 0,
+                .rbp = 0,
+                .r12 = 0,
+                .r13 = 0,
+                .r14 = 0,
+                .r15 = 0,
             };
         }
     };


### PR DESCRIPTION
After running the preemptive scheduler for like an hour, I am pretty confident that preemptive context switches no longer hit a panic